### PR TITLE
[Bug] Remove duplicate compile key in 8B_full.yaml

### DIFF
--- a/recipes/configs/llama3_1/8B_full.yaml
+++ b/recipes/configs/llama3_1/8B_full.yaml
@@ -61,7 +61,6 @@ loss:
   _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
 max_steps_per_epoch: null
 gradient_accumulation_steps: 1
-compile: False
 
 # Training env
 device: cuda


### PR DESCRIPTION
#### Context
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Remove the duplicate compile key which causes the YAML load failure. 